### PR TITLE
Fix gh-pages deploy user

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Deploy to gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx gh-pages -d dist -u "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+        run: npx gh-pages -d dist -u "GitHub Actions Bot <github-actions-bot@users.noreply.github.com>"


### PR DESCRIPTION
## Summary
- update the gh-pages deployment step to use a bot name/email pair that the CLI accepts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e52b9ad48c8327bf063d06c54f3c51